### PR TITLE
Enforce the consistent use of double quotes in JSX attributes (jsx-quotes)

### DIFF
--- a/eslint.react.js
+++ b/eslint.react.js
@@ -5,6 +5,7 @@ module.exports = {
 
   rules: {
     '@ottofeller/ottofeller/jsx-newline-block': ['error'],
+    'jsx-quotes'                              : ['error'],
     'react-hooks/exhaustive-deps'             : ['warn'],
     'react-hooks/rules-of-hooks'              : ['error'],
     'react/destructuring-assignment'          : ['warn', 'never', {ignoreClassFields: true}],


### PR DESCRIPTION
* https://eslint.org/docs/rules/jsx-quotes
* https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IGpzeC1xdW90ZXM6IFtcImVycm9yXCJdICovXG5cbmNvbnN0IHRlbXAgPSAoKSA9PiA8ZGl2XG5cdGE9XCJ0ZXN0XCJcblx0Yj0ndGVzdCdcbi8+Iiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo2LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7ImpzeCI6dHJ1ZX19LCJydWxlcyI6e30sImVudiI6e319fQ==