### PR TITLE
added object-shorthand rule for properties

### DIFF
--- a/eslint.base.js
+++ b/eslint.base.js
@@ -104,6 +104,6 @@ module.exports = {
     'space-infix-ops'                                   : ['off'],
     'spaced-comment'                                    : ['error', 'always'],
     'strict'                                            : ['error', 'never'],
-    'unicorn/prevent-abbreviations'                     : ['error', {replacements: {dir: false, dirs: false, params: false, props: false}}],
+    'unicorn/prevent-abbreviations'                     : ['error', {replacements: {dir: false, dirs: false, ex: {error: true, exception: true}, params: false, props: false}}],
   },
 }

--- a/eslint.base.js
+++ b/eslint.base.js
@@ -77,6 +77,7 @@ module.exports = {
     'no-unused-expressions'                             : ['off'],
     'no-unused-vars'                                    : ['off'],
     'object-curly-spacing'                              : ['off'],
+    'object-shorthand'                                  : ['error', 'always'],
     'one-var'                                           : ['error', 'never'],
     'one-var-declaration-per-line'                      : ['error', 'always'],
     'padded-blocks'                                     : ['error', 'never'],

--- a/eslint.base.js
+++ b/eslint.base.js
@@ -38,6 +38,7 @@ module.exports = {
     'arrow-parens'                                      : ['error', 'as-needed'],
     'capitalized-comments'                              : ['error'],
     'comma-dangle'                                      : ['error', {arrays: 'always-multiline', exports: 'always-multiline', functions: 'always-multiline', imports: 'always-multiline', objects: 'always-multiline'}],
+    'comma-spacing'                                     : ['error'],
     'curly'                                             : ['error', 'all'],
     'eol-last'                                          : ['error'],
     'eqeqeq'                                            : ['error'],


### PR DESCRIPTION
Closes PLA-81, 83, 84.

` object-shorthand`: I have configured the rule to track shorthand syntax only for properties, not for methods. For support of methods need to switch to the "always" option.