### PR TITLE
added prettier as a dependency

### DIFF
--- a/ofmt/package-lock.json
+++ b/ofmt/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-plugin-react-hooks": "4.3.0",
         "eslint-plugin-tailwindcss": "3.4.3",
         "meow": "10.1.2",
+        "prettier": "2.6.2",
         "prettier-plugin-organize-imports": "2.3.4"
       },
       "bin": {
@@ -2593,7 +2594,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
       "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -5152,8 +5152,7 @@
     "prettier": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
-      "peer": true
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew=="
     },
     "prettier-plugin-organize-imports": {
       "version": "2.3.4",

--- a/ofmt/package.json
+++ b/ofmt/package.json
@@ -19,6 +19,7 @@
     "eslint-plugin-react-hooks": "4.3.0",
     "eslint-plugin-tailwindcss": "3.4.3",
     "meow": "10.1.2",
+    "prettier": "2.6.2",
     "prettier-plugin-organize-imports": "2.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Without `prettier` being directly installed with the package `npx` installs (or can install) it in global dir. As a result `prettier` and its plugins reside in different folders and thus `prettier` can't find plugins at runtime.