### PR TITLE
Add exit code 1 for linter errors

### DIFF
--- a/ofmt/bin/olint.js
+++ b/ofmt/bin/olint.js
@@ -18,4 +18,10 @@ void (async function () {
   const results = await eslint.lintFiles(args.input)
   const formatter = await eslint.loadFormatter('stylish')
   console.log(formatter.format(results))
+
+  const totalErrorCount = results.reduce((acc, result) => acc + result.errorCount, 0)
+
+  if (totalErrorCount > 0) {
+    process.exit(1)
+  }
 })()


### PR DESCRIPTION
Without manual exit with non-zero code the script completes normally only showing the messages in logs. In CI it causes linter jobs to be successful even in case of errors.