### PR TITLE
Unify curly braces

### DIFF
--- a/eslint-config-ofmt/eslint.quality.cjs
+++ b/eslint-config-ofmt/eslint.quality.cjs
@@ -26,6 +26,7 @@ module.exports = {
     '@typescript-eslint/no-shadow'            : ['error'],
     '@typescript-eslint/no-unused-expressions': ['error'],
     '@typescript-eslint/no-unused-vars'       : ['error', {argsIgnorePattern: '^_'}],
+    'curly'                                   : ['error'],
     'import/no-relative-parent-imports'       : ['error'],
     'max-depth'                               : ['error', {max: 1}],
     'no-negated-condition'                    : ['error'],


### PR DESCRIPTION
Introduces the `curly` eslint rule which requires wrapping all statements in curly braces.