### PR TITLE
Update prettier-plugin-organize-imports

### DIFF
--- a/ofmt/package-lock.json
+++ b/ofmt/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-tailwindcss": "3.6.0",
         "meow": "10.1.3",
         "prettier": "2.7.1",
-        "prettier-plugin-organize-imports": "3.0.0"
+        "prettier-plugin-organize-imports": "3.1.1"
       },
       "bin": {
         "ofmt": "bin/ofmt.js",
@@ -2991,12 +2991,18 @@
       }
     },
     "node_modules/prettier-plugin-organize-imports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.0.0.tgz",
-      "integrity": "sha512-juSCJs5TMOqGGPaN/A/1xzWFzRPH2LG1LPLCr64dzKaVnPafJdtgDNmDVlU+8A4LbQzVJg0DTvgA8swBuIUhlg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.1.1.tgz",
+      "integrity": "sha512-6bHIQzybqA644h0WGUW3gpWEVbMBvzui5wCMRBi7qA++d5ov2xjjfDk8pxJJ/ardfZrGAwizKMq/fQMFdJ+0Zw==",
       "peerDependencies": {
+        "@volar/vue-typescript": ">=0.40.2",
         "prettier": ">=2.0",
         "typescript": ">=2.9"
+      },
+      "peerDependenciesMeta": {
+        "@volar/vue-typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/prop-types": {
@@ -5793,9 +5799,9 @@
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
     "prettier-plugin-organize-imports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.0.0.tgz",
-      "integrity": "sha512-juSCJs5TMOqGGPaN/A/1xzWFzRPH2LG1LPLCr64dzKaVnPafJdtgDNmDVlU+8A4LbQzVJg0DTvgA8swBuIUhlg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.1.1.tgz",
+      "integrity": "sha512-6bHIQzybqA644h0WGUW3gpWEVbMBvzui5wCMRBi7qA++d5ov2xjjfDk8pxJJ/ardfZrGAwizKMq/fQMFdJ+0Zw==",
       "requires": {}
     },
     "prop-types": {

--- a/ofmt/package.json
+++ b/ofmt/package.json
@@ -20,7 +20,7 @@
     "eslint-plugin-tailwindcss": "3.6.0",
     "meow": "10.1.3",
     "prettier": "2.7.1",
-    "prettier-plugin-organize-imports": "3.0.0"
+    "prettier-plugin-organize-imports": "3.1.1"
   },
   "devDependencies": {
     "@types/node": "18.0.6",


### PR DESCRIPTION
The plugin is just a wrapper around TypeScript organizeImports function. The previous version of the plugin does not work with TypeScript 4.8, because of changed way of handling non-existing methods on a host object - the recent TypeScript implementations throws an error instead of silently continuing. The issue was resolved with the plugin providing an extended host object implementation with all necessary methods present.

Closes PLA-142.