### PR TITLE
Extend the mechanism for finding config and extend it to the eslint config

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,4 +19,9 @@ jobs:
       with:
         node-version: ${{ matrix.version }}
         command: npm run lint
+        directory: ./eslint-config-ofmt
+    - uses: ottofeller/github-actions/npm-run@main
+      with:
+        node-version: ${{ matrix.version }}
+        command: cd ../eslint-config-ofmt && npm ci && cd ../ofmt && npm run lint
         directory: ./ofmt

--- a/eslint-config-ofmt/eslint.formatting.cjs
+++ b/eslint-config-ofmt/eslint.formatting.cjs
@@ -5,7 +5,7 @@
  */
 
 /**
- * @type {import('eslint').Linter.BaseConfig}
+ * @type {import('eslint').Linter.Config}
  */
 module.exports = {
   env    : {browser: true, jest: true, node: true},

--- a/eslint-config-ofmt/eslint.formatting.cjs
+++ b/eslint-config-ofmt/eslint.formatting.cjs
@@ -9,7 +9,7 @@
  */
 module.exports = {
   env    : {browser: true, jest: true, node: true},
-
+  ignorePatterns: '!.projenrc.ts',
   parser       : '@typescript-eslint/parser',
   parserOptions: {ecmaFeatures: {jsx: true}, ecmaVersion: 2020, sourceType: 'module'},
 

--- a/eslint-config-ofmt/eslint.quality.cjs
+++ b/eslint-config-ofmt/eslint.quality.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   env    : {browser: true, jest: true, node: true},
   extends: ['plugin:import/typescript'],
+  ignorePatterns: '!.projenrc.ts',
   globals: {document: 'readonly', navigator: 'readonly', window: 'readonly'},
 
   overrides: [

--- a/eslint-config-ofmt/package-lock.json
+++ b/eslint-config-ofmt/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "eslint": "8.20.0",
-        "typescript": "4.7.4"
+        "typescript": "4.8.4"
       },
       "peerDependencies": {
         "eslint": ">= 8",
@@ -2654,9 +2654,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4562,9 +4562,9 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/eslint-config-ofmt/package-lock.json
+++ b/eslint-config-ofmt/package-lock.json
@@ -18,7 +18,8 @@
         "eslint-plugin-tailwindcss": "3.6.0"
       },
       "devDependencies": {
-        "eslint": "8.20.0"
+        "eslint": "8.20.0",
+        "typescript": "4.7.4"
       },
       "peerDependencies": {
         "eslint": ">= 8",
@@ -2653,10 +2654,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-      "peer": true,
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4562,10 +4562,9 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-      "peer": true
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/eslint-config-ofmt/package.json
+++ b/eslint-config-ofmt/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "eslint": "8.20.0",
-    "typescript": "4.7.4"
+    "typescript": "4.8.4"
   },
   "peerDependencies": {
     "eslint": ">= 8",

--- a/eslint-config-ofmt/package.json
+++ b/eslint-config-ofmt/package.json
@@ -13,7 +13,8 @@
     "eslint-plugin-tailwindcss": "3.6.0"
   },
   "devDependencies": {
-    "eslint": "8.20.0"
+    "eslint": "8.20.0",
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "eslint": ">= 8",

--- a/ofmt/bin/ofmt.js
+++ b/ofmt/bin/ofmt.js
@@ -64,9 +64,11 @@ if (args.input[0] === 'install') {
 } else {
   const checkOrWrite = args.flags.lint ? 'check' : 'write --list-different'
 
+  const eslintExt = '.cjs,.js,.jsx,.ts,.tsx'
+
   ;[
     `npx prettier --${checkOrWrite} --config ${prettierConfigPath} ${args.input}`,
-    `npx eslint --config ${eslintConfigPath} ${args.flags.lint ? '' : '--fix'} ${args.input}`,
+    `npx eslint --ext ${eslintExt} --config ${eslintConfigPath} ${args.flags.lint ? '' : '--fix'} ${args.input}`,
   ].forEach((command) => {
     exec(command, (error, stdout, stderr) => {
       console.log(stdout)

--- a/ofmt/bin/ofmt.js
+++ b/ofmt/bin/ofmt.js
@@ -10,22 +10,44 @@ import {install} from '../lib/install.js'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const packageRoot = path.resolve(__dirname, '..')
 
-const relativePrettierConfigPath = [
-  '../prettier-config-ofmt/index.json', // Path within another package, where 'ofmt' is installed as a dependency.
-  'node_modules/@ottofeller/prettier-config-ofmt/index.json', // Path within this package.
-].find((filePath) => {
-  const fullPath = path.resolve(packageRoot, filePath)
+/**
+ * Find config either as a dependency of ofmt or as a dependency of the parent project.
+ * @param {string} config
+ * @return {string | undefined}
+ */
+const findConfig = (config) => {
+  const foundConfigPath = [
+    `../${config}`, // Path within another package, where 'ofmt' is installed as a dependency.
+    `node_modules/@ottofeller/${config}`, // Path within this package.
+  ].find((filePath) => {
+    const fullPath = path.resolve(packageRoot, filePath)
 
-  try {
-    return statSync(fullPath)
-  } catch {
-    console.warn(`Can't read file ${fullPath}`)
-    return
-  }
-})
+    try {
+      const stats = statSync(fullPath)
 
-if (!relativePrettierConfigPath) {
+      if (stats.isFile()) {
+        return fullPath
+      }
+    } catch {
+      console.warn(`Can't read file ${fullPath}`)
+    }
+  })
+
+  return foundConfigPath && path.resolve(packageRoot, foundConfigPath)
+}
+
+const prettierConfigPath = findConfig('prettier-config-ofmt/index.json')
+const eslintConfigPath = findConfig('eslint-config-ofmt/eslint.formatting.cjs')
+
+if (!prettierConfigPath) {
   console.error('Prettier config file is not found. Please install "@ottofeller/prettier-config-ofmt".')
+}
+
+if (!eslintConfigPath) {
+  console.error('Eslint formatting config file is not found. Please install "@ottofeller/eslint-config-ofmt".')
+}
+
+if (!prettierConfigPath || !eslintConfigPath) {
   process.exit(1)
 }
 
@@ -41,12 +63,6 @@ if (args.input[0] === 'install') {
   install(args.input[1] || './', args.flags.srcPath)
 } else {
   const checkOrWrite = args.flags.lint ? 'check' : 'write --list-different'
-  const prettierConfigPath = path.resolve(packageRoot, relativePrettierConfigPath)
-
-  const eslintConfigPath = path.resolve(
-    packageRoot,
-    'node_modules/@ottofeller/eslint-config-ofmt/eslint.formatting.cjs',
-  )
 
   ;[
     `npx prettier --${checkOrWrite} --config ${prettierConfigPath} ${args.input}`,

--- a/ofmt/package-lock.json
+++ b/ofmt/package-lock.json
@@ -29,7 +29,7 @@
       },
       "devDependencies": {
         "@types/node": "18.0.6",
-        "typescript": "4.7.4"
+        "typescript": "4.8.4"
       },
       "peerDependencies": {
         "eslint": ">= 8",
@@ -3297,9 +3297,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5667,9 +5667,9 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/ofmt/package.json
+++ b/ofmt/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/node": "18.0.6",
-    "typescript": "4.7.4"
+    "typescript": "4.8.4"
   },
   "peerDependencies": {
     "eslint": ">= 8",


### PR DESCRIPTION
The prettier config utilises a mechanism for finding the config in two folders. The eslint formatting config needs to be found the same way, otherwise the config path resolution fails when ofmt is installed in a project.

Closes PLA-137.