### PR TITLE
Add --no-local-confg flag for eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ There are two _bin_ files that perform the code checking:
 - `ofmt` - prettier formatter. Two options are available:\
   `-l, --lint` - a flag to perform checking only. Without the flag `prettier` will rewrite files with fixed formatting.
   `-p, --src-path` - defines search path for source code within `format` and `lint` scripts (the scripts added to a project upon installation). Defaults to `./src`. Used only with `install` command.
+  `-n, --noConfig` - ignores local eslint config files.
 - `olint` - code quality and best practices linter.
 
 ## Examples:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are two _bin_ files that perform the code checking:
 - `ofmt` - prettier formatter. Two options are available:\
   `-l, --lint` - a flag to perform checking only. Without the flag `prettier` will rewrite files with fixed formatting.
   `-p, --src-path` - defines search path for source code within `format` and `lint` scripts (the scripts added to a project upon installation). Defaults to `./src`. Used only with `install` command.
-  `-n, --noConfig` - ignores local eslint config files.
+  `-n, --no-local-config` - ignores local eslint config files.
 - `olint` - code quality and best practices linter.
 
 ## Examples:

--- a/ofmt/bin/ofmt.js
+++ b/ofmt/bin/ofmt.js
@@ -56,7 +56,7 @@ const args = meow({
   flags: {
     lint: {type: 'boolean', alias: 'l'},
     srcPath: {type: 'string', alias: 'p', default: './src'},
-    noConfig: {type: 'boolean', alias: 'n'},
+    localConfig: {type: 'boolean', alias: 'n', default: true},
   },
 })
 
@@ -70,7 +70,7 @@ if (args.input[0] === 'install') {
   ;[
     `npx prettier --${checkOrWrite} --config ${prettierConfigPath} ${args.input}`,
     `npx eslint --ext ${eslintExt} --config ${eslintConfigPath} ${args.flags.lint ? '' : '--fix'} ${
-      args.flags.noConfig ? '--no-eslintrc' : ''
+      args.flags.localConfig ? '' : '--no-eslintrc'
     } ${args.input}`,
   ].forEach((command) => {
     exec(command, (error, stdout, stderr) => {

--- a/ofmt/bin/ofmt.js
+++ b/ofmt/bin/ofmt.js
@@ -56,6 +56,7 @@ const args = meow({
   flags: {
     lint: {type: 'boolean', alias: 'l'},
     srcPath: {type: 'string', alias: 'p', default: './src'},
+    noConfig: {type: 'boolean', alias: 'n'},
   },
 })
 
@@ -68,7 +69,9 @@ if (args.input[0] === 'install') {
 
   ;[
     `npx prettier --${checkOrWrite} --config ${prettierConfigPath} ${args.input}`,
-    `npx eslint --ext ${eslintExt} --config ${eslintConfigPath} ${args.flags.lint ? '' : '--fix'} ${args.input}`,
+    `npx eslint --ext ${eslintExt} --config ${eslintConfigPath} ${args.flags.lint ? '' : '--fix'} ${
+      args.flags.noConfig ? '--no-eslintrc' : ''
+    } ${args.input}`,
   ].forEach((command) => {
     exec(command, (error, stdout, stderr) => {
       console.log(stdout)


### PR DESCRIPTION
### Problem
`eslint` looks for .eslintrc.js config files in a project (including folders above)

### Solution
Pass `--no-eslintrc` flag to `eslint` command so it'd ignore config files other than specified via `--config` flag