### PR TITLE
Add ban-ts-comment rule

### DIFF
--- a/eslint-config-ofmt/eslint.quality.cjs
+++ b/eslint-config-ofmt/eslint.quality.cjs
@@ -23,6 +23,7 @@ module.exports = {
 
   // Static analysis and code quality
   rules: {
+    '@typescript-eslint/ban-ts-comment'       : ["error", {"ts-expect-error": 'allow-with-description', "ts-ignore": 'allow-with-description'}],
     '@typescript-eslint/no-duplicate-imports' : ['error'],
     '@typescript-eslint/no-shadow'            : ['error'],
     '@typescript-eslint/no-unused-expressions': ['error'],


### PR DESCRIPTION
The rule is configured to track ts-related comments (ts-ignore and ts-expect-errod), while allow for js-related ones (ts-check and ts-nocheck).


Closes PLA-188.